### PR TITLE
fix: date math

### DIFF
--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -71,7 +71,6 @@ router.get("/:buoyId/:tableType/lastone", async (req, res) => {
 // Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastday
 router.get("/:buoyId/:tableType/lastday", async (req, res) => {
   const startDatetime = nDaysAgoDate(1);
-  console.log(startDatetime);
   const result = await getRecordsSince(
     req.params.buoyId,
     req.params.tableType,

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -36,7 +36,7 @@ router.param("tableType", (req, res, next, tableType) => {
 });
 
 // helper function to get date n days ago
-const nDaysAgoDate = (n) => new Date(Date.now() - new Date(1970, 0, n));
+const nDaysAgoDate = (n) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
 
 /**
  * @swagger
@@ -71,6 +71,7 @@ router.get("/:buoyId/:tableType/lastone", async (req, res) => {
 // Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastday
 router.get("/:buoyId/:tableType/lastday", async (req, res) => {
   const startDatetime = nDaysAgoDate(1);
+  console.log(startDatetime);
   const result = await getRecordsSince(
     req.params.buoyId,
     req.params.tableType,


### PR DESCRIPTION
Two issues with the subtracting `new Date(1970, 0, n)` from `Date.now()`:
1. the date field is 1 based, so there's an off by one error
2. The timezone of the `new Date` is baked in, so we're also off by 4 or 5 hours