### PR TITLE
MA Buoys + API Hardening

### DIFF
--- a/app/clients/erddap.js
+++ b/app/clients/erddap.js
@@ -36,15 +36,24 @@ const getSingleBuoyGeoJsonData = ({
   const startDate = start ?? "2003-01-01T12:00:00Z";
   const endDate = end ?? "2012-12-31T12:00:00Z";
   idString = idString ?? `"${id}"`;
+  const queryString = `/${datasetId}.geoJson?${variables.join(
+    ","
+  )},${baseVariables.join(
+    ","
+  )}&station_name=${idString}&time>=${startDate}&time<=${endDate}`;
   return erddapClient
-    .get(
-      `/${datasetId}.geoJson?${variables.join(",")},${baseVariables.join(
-        ","
-      )}&station_name=${idString}&time>=${startDate}&time<=${endDate}`
-    )
+    .get(queryString)
     .then((res) => res)
-    .catch((err) => {
-      throw err;
+    .catch((error) => {
+      if (error.response.status >= 400 && error.response.status < 500) {
+        console.log(
+          `Query "${queryString}" resulted in a 400 series error - returning []`
+        );
+        return { data: { features: [] } };
+      } else {
+        console.log(error);
+        throw error;
+      }
     });
 };
 

--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const ash = require("express-async-handler");
 const utils = require("@/utils");
 const common = require("@/routes/erddap/common");
 const { cacheMiddleware } = require("@/middleware/cache");
@@ -58,27 +59,34 @@ router.param("source", (req, res, next, source) => {
 
 // Ex:  http://localhost:8080/erddap/buoy/query?ids=bid2,bid3&variable=WaterTempSurface&start=2010-07-01T12:00:00Z&end=2010-07-05T12:00:00Z
 
-router.get("/:source/query", async (req, res) => {
-  const ids = req.query.ids.split(",");
+router.get(
+  "/:source/query",
+  ash(async (req, res) => {
+    const ids = req.query.ids.split(",");
 
-  // check variables queried exist for this dataset, short circuit if they don't
-  const queryVariables = req.query.variables.split(",");
-  const datasetVariables =
-    mcache.get(`__express__/erddap/${req.params.source}/variables`) ?? [];
-  const variables = queryVariables.filter((v) => datasetVariables.includes(v));
-  if (variables.length === 0) res.send([]);
+    // check variables queried exist for this dataset, short circuit if they don't
+    const queryVariables = req.query.variables.split(",");
+    const datasetVariables =
+      mcache.get(`__express__/erddap/${req.params.source}/variables`) ?? [];
+    const variables = queryVariables.filter((v) =>
+      datasetVariables.includes(v)
+    );
+    if (variables.length === 0) {
+      return res.send([]);
+    }
 
-  const payload = {
-    ids,
-    datasetId: req.datasetId,
-    variables,
-    start: req.query.start,
-    end: req.query.end,
-  };
+    const payload = {
+      ids,
+      datasetId: req.datasetId,
+      variables,
+      start: req.query.start,
+      end: req.query.end,
+    };
 
-  let data = await common.queryErddapBuoys(payload, req.query.numPoints);
-  res.send(data);
-});
+    let data = await common.queryErddapBuoys(payload, req.query.numPoints);
+    res.send(data);
+  })
+);
 
 /**
  * @swagger
@@ -94,10 +102,14 @@ router.get("/:source/query", async (req, res) => {
 
 // Ex:  http://localhost:8080/erddap/buoy/coordinates?ids=bid2,bid3
 
-router.get("/:source/coordinates", cacheMiddleware, async (req, res) => {
-  const data = await common.getBuoyCoordinates(req.datasetId);
-  res.send(data);
-});
+router.get(
+  "/:source/coordinates",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    const data = await common.getBuoyCoordinates(req.datasetId);
+    res.send(data);
+  })
+);
 
 /**
  * @swagger
@@ -112,9 +124,13 @@ router.get("/:source/coordinates", cacheMiddleware, async (req, res) => {
 
 // Ex:  http://localhost:8080/erddap/buoy/summary
 
-router.get("/:source/summary", cacheMiddleware, async (req, res) => {
-  res.send(await common.getSummary(req.params.source));
-});
+router.get(
+  "/:source/summary",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    res.send(await common.getSummary(req.params.source));
+  })
+);
 
 /**
  * @swagger
@@ -129,8 +145,12 @@ router.get("/:source/summary", cacheMiddleware, async (req, res) => {
 
 // Ex:  http://localhost:8080/erddap/buoy/summary
 
-router.get("/:source/variables", cacheMiddleware, async (req, res) => {
-  res.send(await common.getVariables(req.datasetId));
-});
+router.get(
+  "/:source/variables",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    res.send(await common.getVariables(req.datasetId));
+  })
+);
 
 module.exports = router;

--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -68,9 +68,9 @@ router.get(
     const queryVariables = req.query.variables.split(",");
     const datasetVariables =
       mcache.get(`__express__/erddap/${req.params.source}/variables`) ?? [];
-    const variables = queryVariables.filter((v) =>
-      datasetVariables.includes(v)
-    );
+    const variables = queryVariables
+      .filter((v) => datasetVariables.includes(v))
+      .filter((v) => !v.includes("Qualifiers"));
     if (variables.length === 0) {
       return res.send([]);
     }

--- a/app/routes/erddap/common.js
+++ b/app/routes/erddap/common.js
@@ -8,11 +8,13 @@ const utils = require("@/utils");
 
 const datasetMap = {
   buoy: "combined_e784_bee5_492e",
+  mabuoy: "ma_buoy_data_a6c9_12eb_1ec5",
   model: "model_data_77bb_15c2_6ab3",
   plankton: "plankton_time_series_7615_c513_ef8e",
 };
 const summaryUnitMap = {
   buoy: "month",
+  mabuoy: "month",
   model: "year",
   plankton: "month",
 };
@@ -32,19 +34,14 @@ const stationMap = {
   bid16: "Potters Cove",
   bid17: "GSO Dock",
   bid21: "Station II",
+  bid101: "Cole",
+  bid102: "Taunton",
 };
 
 const queryErddapBuoys = async (payload, rawNumPoints) => {
   const numPoints = rawNumPoints ?? 1000;
 
-  let res;
-  try {
-    res = await getMultiBuoyGeoJsonData(payload);
-  } catch (e) {
-    console.log(e.config.url);
-    console.log(e.response.data);
-    return [];
-  }
+  const res = await getMultiBuoyGeoJsonData(payload);
 
   let processed = res.data.features.map((feature) => {
     const date = new Date(feature.properties.time);

--- a/app/routes/erddap/da.js
+++ b/app/routes/erddap/da.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const ash = require("express-async-handler");
 
 const { cacheMiddleware } = require("@/middleware/cache");
 const mcache = require("memory-cache");
@@ -53,10 +54,14 @@ const getSamples = async (coordinates) => {
  *         description: Success! New content is now available.
  *
  */
-router.get("/coordinates", cacheMiddleware, async (req, res) => {
-  const result = await getCoordinates();
-  res.send(result);
-});
+router.get(
+  "/coordinates",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    const result = await getCoordinates();
+    res.send(result);
+  })
+);
 
 /**
  * @swagger
@@ -69,12 +74,17 @@ router.get("/coordinates", cacheMiddleware, async (req, res) => {
  *         description: Success! New content is now available.
  *
  */
-router.get("/samples", cacheMiddleware, async (req, res) => {
-  const coordinates =
-    mcache.get("__express__/erddap/da/coordinates") ?? (await getCoordinates());
-  let data = await getSamples(coordinates);
-  res.send(data);
-});
+router.get(
+  "/samples",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    const coordinates =
+      mcache.get("__express__/erddap/da/coordinates") ??
+      (await getCoordinates());
+    let data = await getSamples(coordinates);
+    res.send(data);
+  })
+);
 
 module.exports = {
   getCoordinates,

--- a/app/routes/erddap/fish.js
+++ b/app/routes/erddap/fish.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const router = express.Router();
+const ash = require("express-async-handler");
 
 const utils = require("@/utils");
 const { cacheMiddleware } = require("@/middleware/cache");
@@ -134,10 +135,14 @@ router.get("/coordinates", (req, res) => {
  *         description: Success! New content is now available.
  *
  */
-router.get("/species", cacheMiddleware, async (req, res) => {
-  let data = await getSpecies();
-  res.send(data);
-});
+router.get(
+  "/species",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    let data = await getSpecies();
+    res.send(data);
+  })
+);
 
 /**
  * @swagger
@@ -150,10 +155,14 @@ router.get("/species", cacheMiddleware, async (req, res) => {
  *         description: Success! New content is now available.
  *
  */
-router.get("/temps", cacheMiddleware, async (req, res) => {
-  const result = await getTemps();
-  res.send(result);
-});
+router.get(
+  "/temps",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    const result = await getTemps();
+    res.send(result);
+  })
+);
 
 /**
  * @swagger

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -1,5 +1,7 @@
 const express = require("express");
 const router = express.Router();
+const ash = require("express-async-handler");
+
 const { getLatestRecord, getRecordsSince } = require("@/clients/telemetry.js");
 
 const BUOY_IDS = ["Buoy-620", "Buoy-720", "Castle_Hill"];
@@ -48,10 +50,16 @@ router.param("tableType", (req, res, next, tableType) => {
  */
 
 // Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastone
-router.get("/:buoyId/:tableType/lastone", async (req, res) => {
-  const result = await getLatestRecord(req.params.buoyId, req.params.tableType);
-  res.send(result);
-});
+router.get(
+  "/:buoyId/:tableType/lastone",
+  ash(async (req, res) => {
+    const result = await getLatestRecord(
+      req.params.buoyId,
+      req.params.tableType
+    );
+    res.send(result);
+  })
+);
 
 /**
  * @swagger
@@ -66,14 +74,17 @@ router.get("/:buoyId/:tableType/lastone", async (req, res) => {
  */
 
 // Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastday
-router.get("/:buoyId/:tableType/lastday", async (req, res) => {
-  const result = await getRecordsSince(
-    req.params.buoyId,
-    req.params.tableType,
-    1
-  );
-  res.send(result);
-});
+router.get(
+  "/:buoyId/:tableType/lastday",
+  ash(async (req, res) => {
+    const result = await getRecordsSince(
+      req.params.buoyId,
+      req.params.tableType,
+      1
+    );
+    res.send(result);
+  })
+);
 
 /**
  * @swagger
@@ -88,13 +99,16 @@ router.get("/:buoyId/:tableType/lastday", async (req, res) => {
  */
 
 // Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastweek
-router.get("/:buoyId/:tableType/lastweek", async (req, res) => {
-  const result = await getRecordsSince(
-    req.params.buoyId,
-    req.params.tableType,
-    7
-  );
-  res.send(result);
-});
+router.get(
+  "/:buoyId/:tableType/lastweek",
+  ash(async (req, res) => {
+    const result = await getRecordsSince(
+      req.params.buoyId,
+      req.params.tableType,
+      7
+    );
+    res.send(result);
+  })
+);
 
 module.exports = router;

--- a/app/server.js
+++ b/app/server.js
@@ -14,7 +14,7 @@ const specs = swaggerJsdoc(swaggerOptions);
 
 app.use(logger("dev"));
 app.use(function (req, res, next) {
-  res.header("Access-Control-Allow-Origin", "*"); // update to match the domain you will make the request from
+  res.header("Access-Control-Allow-Origin", "*");
   res.header("Access-Control-Allow-Headers", "*");
   next();
 });

--- a/app/utils.js
+++ b/app/utils.js
@@ -14,7 +14,6 @@ aq.addFunction("utcsixhours", (x) => {
 });
 
 // downsample the buoy points to approximately the desired number of points
-// TODO: have this handle multiple buoys in one pass
 const downsample = (data, numPoints, variables) => {
   if (data.length === 0) {
     return data;
@@ -30,8 +29,6 @@ const downsample = (data, numPoints, variables) => {
   if (full_dt.numRows <= numPoints) {
     return full_dt.objects();
   }
-
-  // TODO: what to do with non-numeric values??
 
   let stations = full_dt.groupby("station_name").count().objects();
 

--- a/app/utils.js
+++ b/app/utils.js
@@ -16,14 +16,22 @@ aq.addFunction("utcsixhours", (x) => {
 // downsample the buoy points to approximately the desired number of points
 // TODO: have this handle multiple buoys in one pass
 const downsample = (data, numPoints, variables) => {
+  if (data.length === 0) {
+    return data;
+  }
+
   let full_dt = aq
     .from(data)
     .fold(variables, { as: ["variable", "value"] })
-    .filter("d.value");
+    .filter("d.value")
+    .orderby("station_name", "variable", "time")
+    .reify();
 
   if (full_dt.numRows <= numPoints) {
     return full_dt.objects();
   }
+
+  // TODO: what to do with non-numeric values??
 
   let stations = full_dt.groupby("station_name").count().objects();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "arquero": "4",
         "axios": "^0.21.1",
         "express": "^4.17.1",
+        "express-async-handler": "^1.1.4",
         "http-errors": "^1.8.0",
         "memory-cache": "^0.2.0",
         "module-alias": "^2.2.2",
@@ -1727,6 +1728,11 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-async-handler": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.1.4.tgz",
+      "integrity": "sha512-HdmbVF4V4w1q/iz++RV7bUxIeepTukWewiJGkoCKQMtvPF11MLTa7It9PRc/reysXXZSEyD4Pthchju+IUbMiQ=="
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -5611,6 +5617,11 @@
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
+    },
+    "express-async-handler": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.1.4.tgz",
+      "integrity": "sha512-HdmbVF4V4w1q/iz++RV7bUxIeepTukWewiJGkoCKQMtvPF11MLTa7It9PRc/reysXXZSEyD4Pthchju+IUbMiQ=="
     },
     "extend": {
       "version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "license": "MIT",
       "dependencies": {
         "arquero": "4",
-        "axios": "^0.21.1",
+        "axios": "^0.21.4",
         "express": "^4.17.1",
         "express-async-handler": "^1.1.4",
         "http-errors": "^1.8.0",
         "memory-cache": "^0.2.0",
         "module-alias": "^2.2.2",
         "morgan": "^1.10.0",
-        "mysql2": "^2.2.5",
+        "mysql2": "^2.3.0",
         "swagger-jsdoc": "^6.0.1",
         "swagger-ui-express": "^4.1.6"
       },
@@ -25,9 +25,9 @@
         "chai-http": "^4.3.0",
         "cheerio": "*",
         "dotenv-cli": "^4.0.0",
-        "eslint": "^7.18.0",
+        "eslint": "^7.32.0",
         "nodemon": "^2.0.7",
-        "prettier": "^2.3.1"
+        "prettier": "^2.4.1"
       },
       "engines": {
         "node": ">16.0.0"
@@ -476,11 +476,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1390,9 +1390,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
@@ -2722,9 +2722,9 @@
       "dev": true
     },
     "node_modules/mysql2": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.2.5.tgz",
-      "integrity": "sha512-XRqPNxcZTpmFdXbJqb+/CtYVLCx14x1RTeNMD4954L331APu75IC74GDqnZMEt1kwaXy6TySo55rF2F3YJS78g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.0.tgz",
+      "integrity": "sha512-0t5Ivps5Tdy5YHk5NdKwQhe/4Qyn2pload+S+UooDBvsqngtzujG1BaTWBihQLfeKO3t3122/GtusBtmHEHqww==",
       "dependencies": {
         "denque": "^1.4.1",
         "generate-function": "^2.3.1",
@@ -3086,9 +3086,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -4632,11 +4632,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "balanced-match": {
@@ -5343,9 +5343,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -6375,9 +6375,9 @@
       "dev": true
     },
     "mysql2": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.2.5.tgz",
-      "integrity": "sha512-XRqPNxcZTpmFdXbJqb+/CtYVLCx14x1RTeNMD4954L331APu75IC74GDqnZMEt1kwaXy6TySo55rF2F3YJS78g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.0.tgz",
+      "integrity": "sha512-0t5Ivps5Tdy5YHk5NdKwQhe/4Qyn2pload+S+UooDBvsqngtzujG1BaTWBihQLfeKO3t3122/GtusBtmHEHqww==",
       "requires": {
         "denque": "^1.4.1",
         "generate-function": "^2.3.1",
@@ -6655,9 +6655,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -23,20 +23,20 @@
     "chai-http": "^4.3.0",
     "cheerio": "*",
     "dotenv-cli": "^4.0.0",
-    "eslint": "^7.18.0",
+    "eslint": "^7.32.0",
     "nodemon": "^2.0.7",
-    "prettier": "^2.3.1"
+    "prettier": "^2.4.1"
   },
   "dependencies": {
     "arquero": "4",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "express": "^4.17.1",
     "express-async-handler": "^1.1.4",
     "http-errors": "^1.8.0",
     "memory-cache": "^0.2.0",
     "module-alias": "^2.2.2",
     "morgan": "^1.10.0",
-    "mysql2": "^2.2.5",
+    "mysql2": "^2.3.0",
     "swagger-jsdoc": "^6.0.1",
     "swagger-ui-express": "^4.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "arquero": "4",
     "axios": "^0.21.1",
     "express": "^4.17.1",
+    "express-async-handler": "^1.1.4",
     "http-errors": "^1.8.0",
     "memory-cache": "^0.2.0",
     "module-alias": "^2.2.2",


### PR DESCRIPTION
* Add the MA buoy dataset
* Wrap all async route handlers in `ash` (`express-async-handler`)
* Don't try to downsample if there is no data
* prettifying (seems to have made diffs bigger than they really ought to be)
* update dependencies
* always return buoy data in order