### PR TITLE
Add units to variables

### DIFF
--- a/app/clients/erddap.js
+++ b/app/clients/erddap.js
@@ -12,14 +12,9 @@ const erddapClient = axios.create({
   },
 });
 
-const baseVariables = [
-  "time",
-  "latitude",
-  "longitude",
-  "station_name",
-];
+const baseVariables = ["time", "latitude", "longitude", "station_name"];
 
-const nonDataVariables = [...baseVariables, "station_longname", "timezone"]
+const nonDataVariables = [...baseVariables, "station_longname", "timezone"];
 
 const getMultiBuoyGeoJsonData = ({ ids, variables, start, end, datasetId }) => {
   const idString = `~"(${ids.join("|")})"`;

--- a/app/clients/erddap.js
+++ b/app/clients/erddap.js
@@ -1,6 +1,5 @@
 const axios = require("axios");
 const utils = require("@/utils");
-const { NetCDFReader } = require("netcdfjs");
 
 const erddapClient = axios.create({
   baseURL:

--- a/app/clients/erddap.js
+++ b/app/clients/erddap.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const utils = require("@/utils");
+const { NetCDFReader } = require("netcdfjs");
 
 const erddapClient = axios.create({
   baseURL:
@@ -12,7 +13,14 @@ const erddapClient = axios.create({
   },
 });
 
-const baseVariables = ["time", "latitude", "longitude", "station_name"];
+const baseVariables = [
+  "time",
+  "latitude",
+  "longitude",
+  "station_name",
+];
+
+const nonDataVariables = [...baseVariables, "station_longname", "timezone"]
 
 const getMultiBuoyGeoJsonData = ({ ids, variables, start, end, datasetId }) => {
   const idString = `~"(${ids.join("|")})"`;
@@ -59,9 +67,11 @@ const getSingleBuoyGeoJsonData = ({
 
 const getSummaryData = async (datasetId, variables, timeUnit) => {
   const res = await erddapClient.get(
-    `/${datasetId}.json?${variables.join(
-      ","
-    )},station_name,time&orderByCount("station_name,time/${timeUnit}")`
+    `/${datasetId}.json?${variables
+      .map((v) => v.name)
+      .join(
+        ","
+      )},station_name,time&orderByCount("station_name,time/${timeUnit}")`
   );
   return utils.jsonTableToObjects(res.data.table);
 };
@@ -74,19 +84,36 @@ const getBuoysCoordinates = async (datasetId) => {
 };
 
 const getBuoyVariables = async (datasetId) => {
-  let vars = [];
-  const res = await erddapClient.get(`/${datasetId}.dds`);
-  const rows = res.data.split("\n").map((row) => {
-    let line = row.trim();
+  const vars = [];
+  const ddsRes = await erddapClient.get(`/${datasetId}.dds`);
+  const rows = ddsRes.data.split("\n").map((row) => {
+    const line = row.trim();
     if (line.endsWith(";") && !line.includes("}")) {
       let defn = line.substring(0, line.length - 1).split(" ")[1];
-      if (!baseVariables.includes(defn)) {
+      if (!nonDataVariables.includes(defn)) {
         vars.push(defn);
       }
     }
   });
 
-  return vars;
+  // getting the units out in an easily parsable manner without data or already knowing the units is surprisingly tricky.  This approach gets the variable names, then queries for 1 row of data with all of those variables in order to track down the units.
+  const jsonRes = await erddapClient.get(
+    `/${datasetId}.json?${vars.join(",")}&orderByLimit("1")`
+  );
+
+  const unitMap = new Map([
+    ["per cent", "%"],
+    ["degree_C", "°C"],
+    ["data_qualifier", null],
+  ]);
+
+  const table = jsonRes.data.table;
+  return table.columnNames.map((name, i) => ({
+    name,
+    units: unitMap.has(table.columnUnits[i])
+      ? unitMap.get(table.columnUnits[i])
+      : table.columnUnits[i],
+  }));
 };
 
 const getDAData = async ({ sites, datasetId }) => {

--- a/app/middleware/cache.js
+++ b/app/middleware/cache.js
@@ -2,7 +2,6 @@ const mcache = require("memory-cache");
 
 const cacheMiddleware = (req, res, next) => {
   let key = "__express__" + req.originalUrl || req.url;
-  console.log(key);
   let timeout = 60 * 60 * 24 * 1000; // one day of milliseconds
   console.log(key);
   let cachedBody = mcache.get(key);

--- a/app/middleware/cache.js
+++ b/app/middleware/cache.js
@@ -2,6 +2,7 @@ const mcache = require("memory-cache");
 
 const cacheMiddleware = (req, res, next) => {
   let key = "__express__" + req.originalUrl || req.url;
+  console.log(key);
   let timeout = 60 * 60 * 24 * 1000; // one day of milliseconds
   console.log(key);
   let cachedBody = mcache.get(key);

--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -76,15 +76,15 @@ router.get(
 
     let variables;
     if (withUnits) {
-      variables = queryVariables
-        .filter((v) =>
+      variables = queryVariables.filter(
+        (v) =>
+          !v.includes("Qualifiers") &&
           datasetVariables.map((variable) => variable.name).includes(v)
-        )
-        .filter((v) => !v.includes("Qualifiers"));
+      );
     } else {
-      variables = queryVariables
-        .filter((v) => datasetVariables.includes(v))
-        .filter((v) => !v.includes("Qualifiers"));
+      variables = queryVariables.filter(
+        (v) => !v.includes("Qualifiers") && datasetVariables.includes(v)
+      );
     }
 
     if (variables.length === 0) {

--- a/app/routes/erddap/common.js
+++ b/app/routes/erddap/common.js
@@ -78,9 +78,14 @@ const getSummary = async (source) => {
   });
 };
 
-const getVariables = async (datasetId) => {
-  let vars = await getBuoyVariables(datasetId);
-  return vars.sort();
+const getVariables = async (datasetId, withUnits) => {
+  const variables = await getBuoyVariables(datasetId);
+  variables.sort();
+  if (withUnits) {
+    return variables;
+  } else {
+    return variables.map((v) => v.name);
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
* Backwards compatible, units only sent outward with `units=true` passed to query string
* Variables sent as an array of variable names (strings) if no units, of of type `{name, units}[]` if with units