### PR TITLE
Add Core Metrics Endpoint, Ranged Queries

### DIFF
--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -22,35 +22,47 @@ router.param("source", (req, res, next, source) => {
 
 /**
  * @swagger
- * /erddap/:source/query:
+ * /erddap/{source}/query:
  *   get:
  *     description: Get Data from ERDDAP
  *     parameters:
- *      - name: ids
- *        in: query
- *        description: Buoy IDs, comma separated
- *        required: true
- *        type: string
- *      - name: variables
- *        in: query
- *        description: Measurement Variables, comma separated
- *        required: true
- *        type: string
- *      - name: start
- *        in: query
- *        description: Start Time
- *        required: true
- *        type: string
- *      - name: end
- *        in: query
- *        description: End Time
- *        required: true
- *        type: string
- *      - name: numPoints
- *        in: query
- *        description: max number of points to return
- *        required: false
- *        type: integer
+ *       - in: path
+ *         name: source
+ *         required: true
+ *         description: The type of buoy data to get
+ *         type: string
+ *         enum:
+ *           - buoy
+ *           - mabuoy
+ *           - model
+ *           - plankton
+ *       - name: ids
+ *         in: query
+ *         description: Buoy IDs, comma separated
+ *         required: true
+ *         type: string
+ *       - name: variables
+ *         in: query
+ *         description: Measurement Variables, comma separated
+ *         required: true
+ *         type: string
+ *       - name: start
+ *         in: query
+ *         description: Start Time
+ *         required: true
+ *         type: string
+ *         format: date
+ *       - name: end
+ *         in: query
+ *         description: End Time
+ *         required: true
+ *         type: string
+ *         format: date
+ *       - name: numPoints
+ *         in: query
+ *         description: max number of points to return
+ *         required: false
+ *         type: integer
  *     responses:
  *       200:
  *         description: Success! New content is now available.
@@ -103,10 +115,20 @@ router.get(
 
 /**
  * @swagger
- * /erddap/:source/coordinates:
+ * /erddap/{source}/coordinates:
  *   get:
  *     description: Get Buoy Coordinates from ERDDAP
  *     parameters:
+ *       - in: path
+ *         name: source
+ *         required: true
+ *         description: The type of buoy data to get
+ *         type: string
+ *         enum:
+ *           - buoy
+ *           - mabuoy
+ *           - model
+ *           - plankton
  *     responses:
  *       200:
  *         description: Success! New content is now available.
@@ -126,9 +148,20 @@ router.get(
 
 /**
  * @swagger
- * /erddap/:source/summary:
+ * /erddap/{source}/summary:
  *   get:
- *     description: Get Buoy Coordinates from ERDDAP
+ *     description: Get data availability summary from ERDDAP
+ *     parameters:
+ *       - in: path
+ *         name: source
+ *         required: true
+ *         description: The type of buoy data to get
+ *         type: string
+ *         enum:
+ *           - buoy
+ *           - mabuoy
+ *           - model
+ *           - plankton
  *     responses:
  *       200:
  *         description: Success! New content is now available.
@@ -147,9 +180,20 @@ router.get(
 
 /**
  * @swagger
- * /erddap/:source/variables:
+ * /erddap/{source}/variables:
  *   get:
  *     description: Get Variables available for this source dataset
+ *     parameters:
+ *       - in: path
+ *         name: source
+ *         required: true
+ *         description: The type of buoy data to get
+ *         type: string
+ *         enum:
+ *           - buoy
+ *           - mabuoy
+ *           - model
+ *           - plankton
  *     responses:
  *       200:
  *         description: Success! New content is now available.

--- a/app/routes/erddap/fish.js
+++ b/app/routes/erddap/fish.js
@@ -128,7 +128,7 @@ router.get("/coordinates", (req, res) => {
  * @swagger
  * /erddap/fish/species:
  *   get:
- *     description: Get Fish Trawl Catch Species from ERDDAP
+ *     description: Get Fish Trawl Catch Species and counts from ERDDAP
  *     parameters:
  *     responses:
  *       200:
@@ -166,10 +166,56 @@ router.get(
 
 /**
  * @swagger
- * /erddap/fish/info/:species:
+ * /erddap/fish/info/{species}:
  *   get:
  *     description: Get Fish information for a given species
  *     parameters:
+ *       - in: path
+ *         name: species
+ *         required: true
+ *         description: The fish species to fetch data on
+ *         type: string
+ *         enum:
+ *           - Alewife
+ *           - Atlantic Herring
+ *           - Atlantic Rock Crab
+ *           - Blue Crab
+ *           - Blueback Herring
+ *           - Bluefish
+ *           - Butterfish
+ *           - Conch
+ *           - Cunner
+ *           - Fourspot Flounder
+ *           - Goosefish
+ *           - Gulf Stream Flounder
+ *           - Hermit Crabs
+ *           - Horseshoe Crab
+ *           - Jonah Crab
+ *           - Lady Crab
+ *           - Little Skae
+ *           - Lobster
+ *           - Longfin Squid
+ *           - Longhorn Sculpin
+ *           - Mackerel
+ *           - Mantis Shrimp
+ *           - Menhaden
+ *           - Moonfish
+ *           - Northern Searobin
+ *           - Ocean Pout
+ *           - Red Hake
+ *           - Scup
+ *           - Silver Hake
+ *           - Smooth Dogfish
+ *           - Spider Crabs
+ *           - Spiny Dogfish
+ *           - Spotted Hake
+ *           - Starfish
+ *           - Striped Searobin
+ *           - Summer Flounder
+ *           - Tautog
+ *           - Weakfish
+ *           - Windowpane Flounder
+ *           - Winter Flounder
  *     responses:
  *       200:
  *         description: Success! New content is now available.

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -2,7 +2,11 @@ const express = require("express");
 const router = express.Router();
 const ash = require("express-async-handler");
 
-const { getLatestRecord, getRecordsSince } = require("@/clients/telemetry.js");
+const {
+  getLatestRecord,
+  getRecordsSince,
+  getRecordsRange,
+} = require("@/clients/telemetry.js");
 
 const BUOY_IDS = ["Buoy-620", "Buoy-720", "Castle_Hill"];
 const TABLE_TYPES = [
@@ -19,6 +23,45 @@ const TABLE_TYPES = [
   "System",
   "gsmInfo",
 ];
+const RANGES = {
+  lastone: () => (bid, table, variables) =>
+    getLatestRecord(bid, table, variables),
+  lastday: () => (bid, table, variables) =>
+    getRecordsSince(bid, table, 1, variables),
+  lastweek: () => (bid, table, variables) =>
+    getRecordsSince(bid, table, 7, variables),
+  range: (req) => {
+    const startDate = new Date(req.query.start);
+    const endDate = req.query.end ? new Date(req.query.end) : new Date();
+    return (bid, table, variables) =>
+      getRecordsRange(bid, table, startDate, endDate, variables);
+  },
+};
+const CORE_METRICS = {
+  ECO: ["ecoReadingRaw", "ecoFDOM"],
+  Hydrocat: [
+    "hydrocatTemperature",
+    "hydrocatConductivity",
+    "hydrocatDissOxygen",
+    "hydrocatSalinity",
+    "hydrocatFluorescence",
+    "hydrocatTurbidity",
+    "hydrocatPH",
+  ],
+  Hydrocycle: ["CAPO4"],
+  MetData: [
+    "avgWindSpeed",
+    "avgWindDir",
+    "gustWindSpeed",
+    "gustWindDir",
+    "maximetTemperature",
+    "maximetPressure",
+    "maximetHumidity",
+    "maximetPrecipitation",
+    "maximetSolar",
+  ],
+  PAR: ["PARcalibrated"],
+};
 
 // make sure the url matches tables and buoys we know about
 router.param("buoyId", (req, res, next, buoyId) => {
@@ -30,18 +73,60 @@ router.param("buoyId", (req, res, next, buoyId) => {
 });
 
 router.param("tableType", (req, res, next, tableType) => {
-  if (TABLE_TYPES.includes(tableType)) {
+  // CoreMetrics has a dedicated route, we don't want an unknown error, but it's also not
+  // a table
+  if (TABLE_TYPES.includes(tableType) || tableType === "CoreMetrics") {
     next();
   } else {
     next(new Error("unknown Table Type"));
   }
 });
 
+router.param("range", (req, res, next, range) => {
+  const queryFn = RANGES[range];
+  if (queryFn) {
+    req.queryFn = queryFn(req);
+    next();
+  } else {
+    next(new Error("unknown query range type"));
+  }
+});
+
 /**
  * @swagger
- * /telemetry/:buoyId/:tableType/lastone:
+ * /telemetry/:buoyId/CoreMetrics/:range:
  *   get:
- *     description: Get the last telemetry record for this buoy and table type
+ *     description: Get the core metrics telemetry records for this buoy and table type over the requested range
+ *     parameters:
+ *     responses:
+ *       200:
+ *         description: Success! New content is now available.
+ *
+ */
+
+// Ex:  http://localhost:8088/telemetry/Buoy-620/CoreMetrics/lastone
+router.get(
+  "/:buoyId/CoreMetrics/:range",
+  ash(async (req, res) => {
+    const results = await Promise.all(
+      Object.entries(CORE_METRICS).map(async ([table, vars]) => ({
+        [table]: await req.queryFn(req.params.buoyId, table, [
+          "TmStamp",
+          ...vars,
+        ]),
+      }))
+    );
+    // merge the results into one object
+    const result = results.reduce((a, b) => ({ ...a, ...b }), {});
+    res.send(result);
+  })
+);
+
+/**
+ * @swagger
+ * /telemetry/:buoyId/:tableType/:range:
+ *   get:
+ *     description: Get the telemetry records for this buoy and table type over the requested range
  *     parameters:
  *     responses:
  *       200:
@@ -51,62 +136,9 @@ router.param("tableType", (req, res, next, tableType) => {
 
 // Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastone
 router.get(
-  "/:buoyId/:tableType/lastone",
+  "/:buoyId/:tableType/:range",
   ash(async (req, res) => {
-    const result = await getLatestRecord(
-      req.params.buoyId,
-      req.params.tableType
-    );
-    res.send(result);
-  })
-);
-
-/**
- * @swagger
- * /telemetry/:buoyId/:tableType/lastday:
- *   get:
- *     description: Get the last day of telemetry records for this buoy and table type
- *     parameters:
- *     responses:
- *       200:
- *         description: Success! New content is now available.
- *
- */
-
-// Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastday
-router.get(
-  "/:buoyId/:tableType/lastday",
-  ash(async (req, res) => {
-    const result = await getRecordsSince(
-      req.params.buoyId,
-      req.params.tableType,
-      1
-    );
-    res.send(result);
-  })
-);
-
-/**
- * @swagger
- * /telemetry/:buoyId/:tableType/lastweek:
- *   get:
- *     description: Get the last week of telemetry records for this buoy and table type
- *     parameters:
- *     responses:
- *       200:
- *         description: Success! New content is now available.
- *
- */
-
-// Ex:  http://localhost:8088/telemetry/Buoy-620/System/lastweek
-router.get(
-  "/:buoyId/:tableType/lastweek",
-  ash(async (req, res) => {
-    const result = await getRecordsSince(
-      req.params.buoyId,
-      req.params.tableType,
-      7
-    );
+    const result = await req.queryFn(req.params.buoyId, req.params.tableType);
     res.send(result);
   })
 );

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -94,10 +94,41 @@ router.param("range", (req, res, next, range) => {
 
 /**
  * @swagger
- * /telemetry/:buoyId/CoreMetrics/:range:
+ * /telemetry/{buoyId}/CoreMetrics/{range}:
  *   get:
  *     description: Get the core metrics telemetry records for this buoy and table type over the requested range
  *     parameters:
+ *       - in: path
+ *         name: buoyId
+ *         required: true
+ *         description: The ID of the buoy to query
+ *         type: string
+ *         enum:
+ *           - Buoy-620
+ *           - Buoy-720
+ *           - Castle_Hill
+ *       - in: path
+ *         name: range
+ *         required: true
+ *         description: The type of date range to query
+ *         type: string
+ *         enum:
+ *           - lastone
+ *           - lastday
+ *           - lastweek
+ *           - range
+ *       - in: query
+ *         name: start
+ *         required: false
+ *         description: The start date of a `range` query
+ *         type: string
+ *         format: date
+ *       - in: query
+ *         name: end
+ *         required: false
+ *         description: The end date of a `range` query. Defaults to the current date if not included.
+ *         type: string
+ *         format: date
  *     responses:
  *       200:
  *         description: Success! New content is now available.
@@ -124,10 +155,59 @@ router.get(
 
 /**
  * @swagger
- * /telemetry/:buoyId/:tableType/:range:
+ * /telemetry/{buoyId}/{tableType}/{range}:
  *   get:
  *     description: Get the telemetry records for this buoy and table type over the requested range
  *     parameters:
+ *       - in: path
+ *         name: buoyId
+ *         required: true
+ *         description: The ID of the buoy to query
+ *         type: string
+ *         enum:
+ *           - Buoy-620
+ *           - Buoy-720
+ *           - Castle_Hill
+ *       - in: path
+ *         name: tableType
+ *         required: true
+ *         description: The table to retrieve data from
+ *         type: string
+ *         enum:
+ *           - Debug
+ *           - ECO
+ *           - GPSData
+ *           - Hydrocat
+ *           - Hydrocycle
+ *           - MetData
+ *           - PAR
+ *           - Power
+ *           - RAS
+ *           - SUNA
+ *           - System
+ *           - gsmInfo
+ *       - in: path
+ *         name: range
+ *         required: true
+ *         description: The type of date range to query
+ *         type: string
+ *         enum:
+ *           - lastone
+ *           - lastday
+ *           - lastweek
+ *           - range
+ *       - in: query
+ *         name: start
+ *         required: false
+ *         description: The start date of a `range` query
+ *         type: string
+ *         format: date
+ *       - in: query
+ *         name: end
+ *         required: false
+ *         description: The end date of a `range` query. Defaults to the current date if not included.
+ *         type: string
+ *         format: date
  *     responses:
  *       200:
  *         description: Success! New content is now available.

--- a/app/swaggerDef.js
+++ b/app/swaggerDef.js
@@ -1,17 +1,12 @@
-/* istanbul ignore next */
-// This file is an example, it's not functionally used by the module.This
-
-const host = `${process.env.HOST}:${process.env.PORT}`;
-
 module.exports = {
   definition: {
     info: {
       // API informations (required)
       title: "ERDDAP Proxy API", // Title (required)
       version: "0.0.1", // Version (required)
-      description: "Proxy API to process and serve ERDDAP data", // Description (optional)
+      description:
+        "Proxy API to process and serve ERDDAP and buoy telemetry data", // Description (optional)
     },
-    host, // Host (optional)
     basePath: "/", // Base path (optional),
   },
   apis: ["app/routes/**/*.js"],


### PR DESCRIPTION
* Add a `/telemetry/{buoyId}/CoreMetrics/{timeRange}` endpoint which aggregates the metrics defined in #24 for any of our time range queries
* Abstract the telemetry endpoints so it's easier to mix/match timeRanges with the tables / metrics
* Make better use of the swagger docs, so that all of the APIs are correctly documented on `/api-docs`