### PR TITLE
Core metric changes

### DIFF
--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -38,9 +38,7 @@ const RANGES = {
   },
 };
 const CORE_METRICS = {
-  ECO: ["ecoReadingRaw",
-   "ecoFDOM",
-   "ecoStart"],
+  ECO: ["ecoReadingRaw", "ecoFDOM"],
   Hydrocat: [
     "hydrocatTemperature",
     "hydrocatConductivity",
@@ -48,16 +46,18 @@ const CORE_METRICS = {
     "hydrocatSalinity",
     "hydrocatFluorescence",
     "hydrocatTurbidity",
-    "hydrocatPH"],
+    "hydrocatPH",
+  ],
   Hydrocycle: [
-  "CAPO4",
-  "QCflag",
-  "Bubbleflag",
-  "COVflag",
-  "Lowsigflag",
-  "OoRflag",
-  "Mixingflag",
-  "Calflag"]
+    "CAPO4",
+    "QCflag",
+    "Bubbleflag",
+    "COVflag",
+    "Lowsigflag",
+    "OoRflag",
+    "Mixingflag",
+    "Calflag",
+  ],
   SUNA: ["sunaNitrateMicroMol"],
   MetData: [
     "avgWindSpeed",
@@ -68,7 +68,8 @@ const CORE_METRICS = {
     "maximetPressure",
     "maximetHumidity",
     "maximetPrecipitation",
-    "maximetSolar"],
+    "maximetSolar",
+  ],
   PAR: ["PARcalibrated"],
 };
 

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -72,8 +72,10 @@ const CORE_METRICS = {
     "maximetHumidity",
     "maximetPrecipitation",
     "maximetSolar",
+    "maximetStart",
   ],
-  PAR: ["PARcalibrated"],
+  PAR: ["PARcalibrated",
+  "parStart"],
 };
 
 // make sure the url matches tables and buoys we know about

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -48,8 +48,7 @@ const CORE_METRICS = {
     "hydrocatSalinity",
     "hydrocatFluorescence",
     "hydrocatTurbidity",
-    "hydrocatPH",
-    "hydrocatStartTime"],
+    "hydrocatPH"],
   Hydrocycle: [
   "CAPO4",
   "QCflag",
@@ -58,10 +57,8 @@ const CORE_METRICS = {
   "Lowsigflag",
   "OoRflag",
   "Mixingflag",
-  "Calflag",
-  "Hydrocyclestart"]
-  SUNA: ["sunaNitrateMicroMol",
-  "sunaStart"],
+  "Calflag"]
+  SUNA: ["sunaNitrateMicroMol"],
   MetData: [
     "avgWindSpeed",
     "avgWindDir",
@@ -71,10 +68,8 @@ const CORE_METRICS = {
     "maximetPressure",
     "maximetHumidity",
     "maximetPrecipitation",
-    "maximetSolar",
-    "maximetStart"],
-  PAR: ["PARcalibrated",
-  "parStart"],
+    "maximetSolar"],
+  PAR: ["PARcalibrated"],
 };
 
 // make sure the url matches tables and buoys we know about
@@ -157,6 +152,7 @@ router.get(
       Object.entries(CORE_METRICS).map(async ([table, vars]) => ({
         [table]: await req.queryFn(req.params.buoyId, table, [
           "TmStamp",
+          `${table.toLowerCase()}Start`,
           ...vars,
         ]),
       }))

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -38,7 +38,9 @@ const RANGES = {
   },
 };
 const CORE_METRICS = {
-  ECO: ["ecoReadingRaw", "ecoFDOM"],
+  ECO: ["ecoReadingRaw",
+   "ecoFDOM",
+   "ecoStart"],
   Hydrocat: [
     "hydrocatTemperature",
     "hydrocatConductivity",
@@ -47,9 +49,19 @@ const CORE_METRICS = {
     "hydrocatFluorescence",
     "hydrocatTurbidity",
     "hydrocatPH",
-  ],
-  Hydrocycle: ["CAPO4"],
-  SUNA: ["sunaNitrateMicroMol"],
+    "hydrocatStartTime"],
+  Hydrocycle: [
+  "CAPO4",
+  "QCflag",
+  "Bubbleflag",
+  "COVflag",
+  "Lowsigflag",
+  "OoRflag",
+  "Mixingflag",
+  "Calflag",
+  "Hydrocyclestart"]
+  SUNA: ["sunaNitrateMicroMol",
+  "sunaStart"],
   MetData: [
     "avgWindSpeed",
     "avgWindDir",

--- a/app/routes/telemetry/index.js
+++ b/app/routes/telemetry/index.js
@@ -72,8 +72,7 @@ const CORE_METRICS = {
     "maximetHumidity",
     "maximetPrecipitation",
     "maximetSolar",
-    "maximetStart",
-  ],
+    "maximetStart"],
   PAR: ["PARcalibrated",
   "parStart"],
 };


### PR DESCRIPTION
Added in the columns for PAR and Maximet start times to core metrics table. Data with start times for these tables should come in after the 6pm data pull from the buoys. 