### PR TITLE
feat: add telemetry-raw route to erddap

### DIFF
--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -15,7 +15,9 @@ router.param("source", (req, res, next, source) => {
     next();
   } else {
     next(
-      new Error("unknown erddap source, only buoy, model or plankton allowed")
+      new Error(
+        "unknown erddap source, only buoy, telemetry-raw, model or plankton allowed"
+      )
     );
   }
 });
@@ -174,7 +176,8 @@ router.get(
   "/:source/summary",
   cacheMiddleware,
   ash(async (req, res) => {
-    res.send(await common.getSummary(req.params.source));
+    const summary = await common.getSummary(req.params.source);
+    res.send(summary);
   })
 );
 

--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -176,8 +176,7 @@ router.get(
   "/:source/summary",
   cacheMiddleware,
   ash(async (req, res) => {
-    const summary = await common.getSummary(req.params.source);
-    res.send(summary);
+    res.send(await common.getSummary(req.params.source));
   })
 );
 

--- a/app/routes/erddap/common.js
+++ b/app/routes/erddap/common.js
@@ -41,6 +41,8 @@ const stationMap = {
   bid21: "Station II",
   bid101: "Cole",
   bid102: "Taunton",
+
+  // TODO: waiting for proper name mappings on the telemetry buoys
   "Buoy-720": "Buoy 720",
   "Buoy-620": "Buoy 620",
   Castle_Hill: "Castle Hill",

--- a/app/routes/erddap/common.js
+++ b/app/routes/erddap/common.js
@@ -11,12 +11,14 @@ const datasetMap = {
   mabuoy: "ma_buoy_data_a6c9_12eb_1ec5",
   model: "model_data_77bb_15c2_6ab3",
   plankton: "plankton_time_series_7615_c513_ef8e",
+  "telemetry-raw": "buoy_telemetry_0ffe_2dc0_916e",
 };
 const summaryUnitMap = {
   buoy: "month",
   mabuoy: "month",
   model: "year",
   plankton: "month",
+  "telemetry-raw": "day",
 };
 const downsampleDataset = {
   plankton: false,
@@ -39,6 +41,9 @@ const stationMap = {
   bid21: "Station II",
   bid101: "Cole",
   bid102: "Taunton",
+  "Buoy-720": "Buoy 720",
+  "Buoy-620": "Buoy 620",
+  Castle_Hill: "Castle Hill",
 };
 
 const queryErddapBuoys = async (payload, rawNumPoints, dataset) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "buoy-api",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
* Add the `telemetry-raw` route to the `erddap` api using the standard buoy routes (`/variables` `/coordinates` `/query` `/summary`)
* Summarize at the `day` level as we know this data is trailing three months (we probably won't use this route, but just in case, made a reasonable guess at how we would use it)