### PR TITLE
feat: add route to get the min/max time for a dataset

### DIFF
--- a/app/clients/erddap.js
+++ b/app/clients/erddap.js
@@ -110,6 +110,14 @@ const getBuoyVariables = async (datasetId) => {
   }));
 };
 
+const getBuoyTimeRange = async (datasetId) => {
+  const jsonRes = await erddapClient.get(
+    `/${datasetId}.json?time&orderByMinMax("time")`
+  );
+  const res = utils.jsonTableToObjects(jsonRes.data.table);
+  return { min: res[0].time, max: res[1].time };
+};
+
 const getDAData = async ({ sites, datasetId }) => {
   const siteString = `~"(${sites.join("|")})"`;
   const res = await erddapClient.get(
@@ -131,6 +139,7 @@ module.exports = {
   getBuoysCoordinates,
   getBuoyVariables,
   getSummaryData,
+  getBuoyTimeRange,
   getDAData,
   getFishData,
 };

--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const ash = require("express-async-handler");
 const utils = require("@/utils");
 const common = require("@/routes/erddap/common");
+const { getBuoyTimeRange } = require("@/clients/erddap");
 const { cacheMiddleware } = require("@/middleware/cache");
 const mcache = require("memory-cache");
 
@@ -210,6 +211,15 @@ router.get(
   ash(async (req, res) => {
     const variables = await common.getVariables(req.datasetId);
     res.send(variables);
+  })
+);
+
+router.get(
+  "/:source/timerange",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    const range = await getBuoyTimeRange(req.datasetId);
+    res.send(range);
   })
 );
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   },
   "scripts": {
     "start": "dotenv -e .env node app/server.js",
-    "dev": "dotenv -e .env.dev nodemon app/server.js",
-    "dev:local": "BUOY_API_ERDDAP_URL=http://localhost:8080/erddap/tabledap nodemon app/server.js",
+    "dev": "dotenv -e .env nodemon app/server.js",
+    "dev:telemetry:local": "dotenv -e .env.dev nodemon app/server.js",
+    "dev:erddap:local": "BUOY_API_ERDDAP_URL=http://localhost:8080/erddap/tabledap nodemon app/server.js",
     "test": "mocha",
     "jsdoc": "jsdoc app/server.js",
     "swagger": "swagger-jsdoc -d app/swaggerDef.js app/routes/content.js",


### PR DESCRIPTION
* realized the min/max date we use in the buoy-viewer isn't correct as it's the min/max first of the month/year/date for the summary
* this returns the true min/max date