### PR TITLE
feat: update real-time buoy names in the api

### DIFF
--- a/app/routes/erddap/common.js
+++ b/app/routes/erddap/common.js
@@ -42,9 +42,9 @@ const stationMap = {
   bid101: "Cole",
   bid102: "Taunton",
 
-  // TODO: waiting for proper name mappings on the telemetry buoys
-  "Buoy-720": "Buoy 720",
-  "Buoy-620": "Buoy 620",
+  // Real-time buoys below this line
+  "Buoy-720": "Potowomut",
+  "Buoy-620": "Conanicut",
   Castle_Hill: "Castle Hill",
 };
 


### PR DESCRIPTION
Updating the real-time buoy names with geo-specific names from the URI research team. This will trickle down to the new real-time buoy page on the RIDDC webpage.