### PR TITLE
update readme and logging with date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 content
 out
 yarn-error.log
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ BUOY_TELEMETRY_MYSQL_DATABASE=buoy_telemetry
 ```
 
 The built/deployed version uses the `.env` file with the same keys but with the service account.
+
+## Restarting Production API
+
+After changes or updates to the servers, the BKE cluster needs to be restarted.
+
+•	`kubectl get deployments` should return `riddc-api`
+•   `kubectl get pods` should show the age of the last restart
+•	`kubectl rollout restart deployment/riddc-api`
+•	`kubectl describe pod [pod name]` – gets info on the deployment
+
+See https://github.com/brown-ccv/k8s-deploy-bke/tree/main/riddc-api

--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ BUOY_TELEMETRY_MYSQL_DATABASE=buoy_telemetry
 
 The built/deployed version uses the `.env` file with the same keys but with the service account.
 
-## Restarting Production API
+## Production Deployment
 
-After changes or updates to the servers, the BKE cluster needs to be restarted.
-
-•	`kubectl get deployments` should return `riddc-api`
-•   `kubectl get pods` should show the age of the last restart
-•	`kubectl rollout restart deployment/riddc-api`
-•	`kubectl describe pod [pod name]` – gets info on the deployment
-
-See https://github.com/brown-ccv/k8s-deploy-bke/tree/main/riddc-api
+The deployment lives on the BKE cluster `bkpd-rancher`. See https://github.com/brown-ccv/k8s-deploy-bke/tree/main/riddc-api for more info on the deployment and troubleshooting.

--- a/app/server.js
+++ b/app/server.js
@@ -12,7 +12,7 @@ const port = 8088;
 
 const specs = swaggerJsdoc(swaggerOptions);
 
-app.use(logger("dev"));
+app.use(logger("[:date[web]] :method :url :status :res[content-length] - :remote-addr - :response-time ms"));
 app.use(function (req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
   res.header("Access-Control-Allow-Headers", "*");


### PR DESCRIPTION
This PR updates the logging so we can better troubleshoot with timestamps after server updates. It also adds some context to the README for restarting the deployment.