### PR TITLE
add tag to build on push

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -2,6 +2,9 @@
 
 name: Build and Push Buoy API Container
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -36,8 +39,6 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{raw}},value=v${{ env.VERSION }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -36,7 +36,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: latest
+          tags: |
+            type=semver,pattern={{raw}},value=v${{ env.VERSION }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This PR add the `tag` to the workflow to build the tagged version on pushes. It will also need to be updated on https://github.com/brown-ccv/k8s-deploy-bke/tree/main/riddc-api in the brown-ccv org repository with the latest version of the build.