### PR TITLE
update the pointer to the new qa erddap deployment

### DIFF
--- a/app/clients/erddap.js
+++ b/app/clients/erddap.js
@@ -4,7 +4,7 @@ const utils = require("@/utils");
 const erddapClient = axios.create({
   baseURL:
     process.env.BUOY_API_ERDDAP_URL ??
-    "https://pricaimcit.services.brown.edu/erddap/tabledap",
+    "https://qa-erddap.riddc.brown.edu/erddap/tabledap",
   withCredentials: false,
   headers: {
     Accept: "application/json",


### PR DESCRIPTION
This is just a small PR to update the link to the new ERDDAP QA deployment so the api will pull from there instead of the old deployment that will be deprecated.