### PR TITLE
fix: remove empty params blocks in swagger specifications

### DIFF
--- a/app/routes/erddap/da.js
+++ b/app/routes/erddap/da.js
@@ -48,7 +48,6 @@ const getSamples = async (coordinates) => {
  * /erddap/da/coordinates:
  *   get:
  *     description: Get Domoic Acid Sample Locations ERDDAP
- *     parameters:
  *     responses:
  *       200:
  *         description: Success! New content is now available.
@@ -68,7 +67,6 @@ router.get(
  * /erddap/da/samples:
  *   get:
  *     description: Get Domoic Acid Samples from ERDDAP
- *     parameters:
  *     responses:
  *       200:
  *         description: Success! New content is now available.

--- a/app/routes/erddap/fish.js
+++ b/app/routes/erddap/fish.js
@@ -114,7 +114,6 @@ const getMonthlyTemps = (temps) => {
  * /erddap/fish/coordinates:
  *   get:
  *     description: Get Fish Trawl Survey Locations ERDDAP
- *     parameters:
  *     responses:
  *       200:
  *         description: Success! New content is now available.
@@ -129,7 +128,6 @@ router.get("/coordinates", (req, res) => {
  * /erddap/fish/species:
  *   get:
  *     description: Get Fish Trawl Catch Species and counts from ERDDAP
- *     parameters:
  *     responses:
  *       200:
  *         description: Success! New content is now available.
@@ -149,7 +147,6 @@ router.get(
  * /erddap/fish/temps:
  *   get:
  *     description: Get Fish Trawl Survey Water Temps from ERDDAP
- *     parameters:
  *     responses:
  *       200:
  *         description: Success! New content is now available.


### PR DESCRIPTION
This PR is the fix for the Swagger front-end hanging on some routes. 

Kudos @eldu for spotting the fix. We had empty parameters blocks that used to work before we updated `node` and the swagger dependencies. Simply deleting them avoids the hang where Swagger was looking for params but not finding any.
