### PR TITLE
[feat]: Buoy Summary Mean Endpoint

### DIFF
--- a/app/clients/erddap.js
+++ b/app/clients/erddap.js
@@ -70,6 +70,17 @@ const getSummaryData = async (datasetId, variables, timeUnit) => {
   return utils.jsonTableToObjects(res.data.table);
 };
 
+const getSummaryMeanData = async (datasetId, variables, timeUnit) => {
+  const res = await erddapClient.get(
+    `/${datasetId}.json?${variables
+      .map((v) => v.name)
+      .join(
+        ","
+      )},station_name,time&orderByMean("station_name,time/${timeUnit}")`
+  );
+  return utils.jsonTableToObjects(res.data.table);
+};
+
 const getBuoysCoordinates = async (datasetId) => {
   const res = await erddapClient.get(
     `/${datasetId}.json?station_name,longitude,latitude&distinct()`
@@ -139,6 +150,7 @@ module.exports = {
   getBuoysCoordinates,
   getBuoyVariables,
   getSummaryData,
+  getSummaryMeanData,
   getBuoyTimeRange,
   getDAData,
   getFishData,

--- a/app/routes/erddap/buoy.js
+++ b/app/routes/erddap/buoy.js
@@ -186,6 +186,39 @@ router.get(
 
 /**
  * @swagger
+ * /erddap/{source}/summary-mean:
+ *   get:
+ *     description: Get mean value per month from ERDDAP
+ *     parameters:
+ *       - in: path
+ *         name: source
+ *         required: true
+ *         description: The type of buoy data to get
+ *         type: string
+ *         enum:
+ *           - buoy
+ *           - mabuoy
+ *           - model
+ *           - plankton
+ *           - telemetry-raw
+ *     responses:
+ *       200:
+ *         description: Success! New content is now available.
+ *
+ */
+
+// Ex:  http://localhost:8080/erddap/buoy/summary-mean
+
+router.get(
+  "/:source/summary-mean",
+  cacheMiddleware,
+  ash(async (req, res) => {
+    res.send(await common.getSummaryMean(req.params.source));
+  })
+);
+
+/**
+ * @swagger
  * /erddap/{source}/variables:
  *   get:
  *     description: Get Variables available for this source dataset

--- a/app/routes/erddap/common.js
+++ b/app/routes/erddap/common.js
@@ -3,6 +3,7 @@ const {
   getBuoysCoordinates,
   getBuoyVariables,
   getSummaryData,
+  getSummaryMeanData,
 } = require("@/clients/erddap");
 const utils = require("@/utils");
 
@@ -95,6 +96,21 @@ const getSummary = async (source) => {
   });
 };
 
+const getSummaryMean = async (source) => {
+  const datasetId = datasetMap[source];
+  const variables = await getBuoyVariables(datasetId);
+  const res = await getSummaryMeanData(
+    datasetId,
+    variables,
+    summaryUnitMap[source]
+  );
+  return res.map((row) => {
+    row.buoyId = row.station_name;
+    row.station_name = `${stationMap[row.buoyId]} (${row.buoyId})`;
+    return row;
+  });
+};
+
 const getVariables = async (datasetId) => {
   const variables = await getBuoyVariables(datasetId);
   variables.sort();
@@ -105,6 +121,7 @@ module.exports = {
   queryErddapBuoys,
   getBuoyCoordinates,
   getSummary,
+  getSummaryMean,
   getVariables,
   stationMap,
   datasetMap,


### PR DESCRIPTION
I added a quick endpoint to create a month by month summary of datasets. This shouldn't change any existing functionality, but should allow for some prototyping of new dashboards like we were talking about yesterday.